### PR TITLE
Add endpoint to get version sets; fix tests

### DIFF
--- a/PlanGrid.Api.Tests/AttachmentTests.cs
+++ b/PlanGrid.Api.Tests/AttachmentTests.cs
@@ -94,7 +94,7 @@ namespace PlanGrid.Api.Tests
             IPlanGridApi client = PlanGridClient.Create();
             Page<Attachment> attachments = await client.GetAttachments(TestData.Project1Uid);
             Assert.AreEqual(1, attachments.Data.Count(x => !x.IsDeleted));
-            Assert.AreEqual("0f1358c4-3cb4-4f68-ab46-2bebfc788ae9", attachments.Data[0].Uid);
+            Assert.AreEqual("49ffb02f-a28d-970e-e8bc-9256a4fbae1c", attachments.Data[0].Uid);
         }
     }
 }

--- a/PlanGrid.Api.Tests/PlanGrid.Api.Tests.csproj
+++ b/PlanGrid.Api.Tests/PlanGrid.Api.Tests.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>PlanGrid.Api.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,6 +64,7 @@
     <Compile Include="TestData.cs" />
     <Compile Include="UserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VersionSetTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/PlanGrid.Api.Tests/TestData.cs
+++ b/PlanGrid.Api.Tests/TestData.cs
@@ -23,7 +23,11 @@ namespace PlanGrid.Api.Tests
         public const string InvitedUserEmail = "kirk+apiinvitee@plangrid.com";
         public const string AdminRoleId = "9d139e64-cac9-4f23-b4d5-9fd3688b498e";
         public const string SnapshotUid = "59F884BA-1CDC-459C-B302-3532E13DBB9A";
+        public const string VersionSet1Uid = "f160b073-c249-4246-8e77-c53ec3c272e0";
+        public const string VersionSet1Name = "Initial Set";
+        public static DateTime VersionSet1PublishDate => new DateTime(2015, 11, 12);
 
         public static readonly string RateLimitedPlanGridApiKey = Environment.GetEnvironmentVariable("PLANGRIDAPIKEY_LIMITED");
+
     }
 }

--- a/PlanGrid.Api.Tests/VersionSetTests.cs
+++ b/PlanGrid.Api.Tests/VersionSetTests.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="VersionSetTests.cs" company="PlanGrid, Inc.">
+//     Copyright (c) 2017 PlanGrid, Inc. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace PlanGrid.Api.Tests
+{
+    [TestFixture]
+    public class VersionSetTests
+    {
+        [Test]
+        public async Task GetVersionSets()
+        {
+            IPlanGridApi client = PlanGridClient.Create();
+            Page<VersionSet> versionSets = await client.GetVersionSets(TestData.Project1Uid);
+            Assert.AreEqual(1, versionSets.Data.Length);
+            VersionSet versionSet = versionSets.Data[0];
+            Assert.AreEqual(TestData.VersionSet1Uid, versionSet.Uid);
+            Assert.AreEqual(TestData.VersionSet1Name, versionSet.Name);
+            Assert.AreEqual(TestData.VersionSet1PublishDate, versionSet.PublishDate);
+        }
+    }
+}

--- a/PlanGrid.Api/IPlanGridApi.cs
+++ b/PlanGrid.Api/IPlanGridApi.cs
@@ -165,5 +165,8 @@ namespace PlanGrid.Api
 
         [Get("/projects/{projectUid}/snapshots")]
         Task<Page<Snapshot>> GetSnapshots(string projectUid, int skip = Page.Skip, int limit = Page.Limit, DateTime? updated_after = null);
+
+        [Get("/projects/{projectUid}/version_sets")]
+        Task<Page<VersionSet>> GetVersionSets(string projectUid, int skip = Page.Skip, int limit = Page.Limit);
     }
 }

--- a/PlanGrid.Api/PlanGrid.Api.projitems
+++ b/PlanGrid.Api/PlanGrid.Api.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentUpload.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)VersionSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileUploadRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileUploadRequestStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonConverters\BaseUrlParameterFormatter.cs" />

--- a/PlanGrid.Api/VersionSet.cs
+++ b/PlanGrid.Api/VersionSet.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="Project.cs" company="PlanGrid, Inc.">
+//     Copyright (c) 2017 PlanGrid, Inc. All rights reserved.
+// </copyright>
+using System;
+using Newtonsoft.Json;
+
+
+namespace PlanGrid.Api
+{
+    public class VersionSet : Record
+    {
+        [JsonProperty("version_name")]
+        public string Name { get; set; }
+
+        [JsonProperty("published_at")]
+        public DateTime? PublishDate { get; set; }
+    }
+}


### PR DESCRIPTION
Seems as though there is one broken test that is actually a broken api.

i've asked the documents team to fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plangrid/plangrid-api-net/11)
<!-- Reviewable:end -->
