### PR TITLE
New version apis

### DIFF
--- a/PlanGrid.Api.Tests/AttachmentTests.cs
+++ b/PlanGrid.Api.Tests/AttachmentTests.cs
@@ -94,7 +94,7 @@ namespace PlanGrid.Api.Tests
             IPlanGridApi client = PlanGridClient.Create();
             Page<Attachment> attachments = await client.GetAttachments(TestData.Project1Uid);
             Assert.AreEqual(1, attachments.Data.Count(x => !x.IsDeleted));
-            Assert.AreEqual("0f1358c4-3cb4-4f68-ab46-2bebfc788ae9", attachments.Data[0].Uid);
+            Assert.AreEqual("49ffb02f-a28d-970e-e8bc-9256a4fbae1c", attachments.Data[0].Uid);
         }
     }
 }

--- a/PlanGrid.Api.Tests/PlanGrid.Api.Tests.csproj
+++ b/PlanGrid.Api.Tests/PlanGrid.Api.Tests.csproj
@@ -11,6 +11,8 @@
     <AssemblyName>PlanGrid.Api.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <TestProjectType>UnitTest</TestProjectType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -62,6 +64,7 @@
     <Compile Include="TestData.cs" />
     <Compile Include="UserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="VersionSetTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config">

--- a/PlanGrid.Api.Tests/SheetTests.cs
+++ b/PlanGrid.Api.Tests/SheetTests.cs
@@ -51,5 +51,15 @@ namespace PlanGrid.Api.Tests
 
             await client.UploadVersion(TestData.Project2Uid, $"Version.{Guid.NewGuid()}", new VirtualFile { FileName = "Sample.pdf", Data = typeof(SheetTests).Assembly.GetManifestResourceStream("PlanGrid.Api.Tests.TestData.Sample.pdf") });
         }
+
+        [Test]
+        public async Task GetSheetsByVersionSet()
+        {
+            IPlanGridApi client = PlanGridClient.Create();
+            Page<Sheet> sheets = await client.GetSheets(TestData.Project1Uid, version_set: TestData.Project1VersionSet1Uid);
+            Assert.Less(0, sheets.Data.Length);
+            Page<Sheet> sheets_empty = await client.GetSheets(TestData.Project1Uid, version_set: TestData.NotFoundUid);
+            Assert.AreEqual(0, sheets_empty.Data.Length);
+        }
     }
 }

--- a/PlanGrid.Api.Tests/TestData.cs
+++ b/PlanGrid.Api.Tests/TestData.cs
@@ -11,6 +11,7 @@ namespace PlanGrid.Api.Tests
         public const string Project1Uid = "d1e8e222-b05b-e750-74e4-d19b92c25506";
         public const string Project1Issue1Uid = "45460feb-2c09-663f-352f-d053444b138a";
         public const string Project1Rfi1Uid = "a3d1c702-3bed-c496-8cf0-6535218cce00";
+        public const string Project1VersionSet1Uid = "f160b073-c249-4246-8e77-c53ec3c272e0";
         public const string Project2Uid = "269ad633-0688-395e-5c30-cc685e0ce964";
         public const string Project2DraftRfiStatusUid = "00a8b880";
         public const string Project2OpenRfiStatusUid = "bcadf1c9";
@@ -23,7 +24,11 @@ namespace PlanGrid.Api.Tests
         public const string InvitedUserEmail = "kirk+apiinvitee@plangrid.com";
         public const string AdminRoleId = "9d139e64-cac9-4f23-b4d5-9fd3688b498e";
         public const string SnapshotUid = "59F884BA-1CDC-459C-B302-3532E13DBB9A";
+        public const string VersionSet1Name = "Initial Set";
+        public static DateTime VersionSet1PublishDate => new DateTime(2015, 11, 12);
+        public const string NotFoundUid = "00000000-0000-0000-0000-000000000000";
 
         public static readonly string RateLimitedPlanGridApiKey = Environment.GetEnvironmentVariable("PLANGRIDAPIKEY_LIMITED");
+
     }
 }

--- a/PlanGrid.Api.Tests/VersionSetTests.cs
+++ b/PlanGrid.Api.Tests/VersionSetTests.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="VersionSetTests.cs" company="PlanGrid, Inc.">
+//     Copyright (c) 2017 PlanGrid, Inc. All rights reserved.
+// </copyright>
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace PlanGrid.Api.Tests
+{
+    [TestFixture]
+    public class VersionSetTests
+    {
+        [Test]
+        public async Task GetVersionSets()
+        {
+            IPlanGridApi client = PlanGridClient.Create();
+            Page<VersionSet> versionSets = await client.GetVersionSets(TestData.Project1Uid);
+            Assert.AreEqual(1, versionSets.Data.Length);
+            VersionSet versionSet = versionSets.Data[0];
+            Assert.AreEqual(TestData.Project1VersionSet1Uid, versionSet.Uid);
+            Assert.AreEqual(TestData.VersionSet1Name, versionSet.Name);
+            Assert.AreEqual(TestData.VersionSet1PublishDate, versionSet.PublishDate);
+        }
+    }
+}

--- a/PlanGrid.Api/IPlanGridApi.cs
+++ b/PlanGrid.Api/IPlanGridApi.cs
@@ -131,7 +131,7 @@ namespace PlanGrid.Api
         Task<Photo> UpdatePhoto(string projectUid, string photoUid, [Body]PhotoUpdate photo);
 
         [Get("/projects/{projectUid}/sheets")]
-        Task<Page<Sheet>> GetSheets(string projectUid, int skip = Page.Skip, int limit = Page.Limit, DateTime? updated_after = null);
+        Task<Page<Sheet>> GetSheets(string projectUid, int skip = Page.Skip, int limit = Page.Limit, DateTime? updated_after = null, string version_set = null);
 
         [Get("/projects/{projectUid}/snapshots/{snapshotUid}")]
         Task<Snapshot> GetSnapshot(string projectUid, string snapshotUid);

--- a/PlanGrid.Api/IPlanGridApi.cs
+++ b/PlanGrid.Api/IPlanGridApi.cs
@@ -165,5 +165,8 @@ namespace PlanGrid.Api
 
         [Get("/projects/{projectUid}/snapshots")]
         Task<Page<Snapshot>> GetSnapshots(string projectUid, int skip = Page.Skip, int limit = Page.Limit, DateTime? updated_after = null);
+
+        [Get("/projects/{projectUid}/version_sets")]
+        Task<Page<VersionSet>> GetVersionSets(string projectUid, int skip = Page.Skip, int limit = Page.Limit);
     }
 }

--- a/PlanGrid.Api/PlanGrid.Api.projitems
+++ b/PlanGrid.Api/PlanGrid.Api.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentReference.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentUpdate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AttachmentUpload.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)VersionSet.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileUploadRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FileUploadRequestStatus.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonConverters\BaseUrlParameterFormatter.cs" />

--- a/PlanGrid.Api/VersionSet.cs
+++ b/PlanGrid.Api/VersionSet.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="Project.cs" company="PlanGrid, Inc.">
+//     Copyright (c) 2017 PlanGrid, Inc. All rights reserved.
+// </copyright>
+using System;
+using Newtonsoft.Json;
+
+
+namespace PlanGrid.Api
+{
+    public class VersionSet : Record
+    {
+        [JsonProperty("version_name")]
+        public string Name { get; set; }
+
+        [JsonProperty("published_at")]
+        public DateTime? PublishDate { get; set; }
+    }
+}


### PR DESCRIPTION
For some reason my old PR stopped updating when I pushed new commits onto the branch :?

anyhow this has a few changes:

- Fixes one broken test--the old attachment id appears to be marked as deleted
- adds support for getting version sets for a project
- adds support to get sheets based on a version set

and, as in the other pr, i'm working with the customer api team to get the api break fixed for the broken  test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plangrid/plangrid-api-net/13)
<!-- Reviewable:end -->
