### PR TITLE
Use proper Authn header when contacting capi-d

### DIFF
--- a/PlanGrid.Api/PlanGridHttpHandler.cs
+++ b/PlanGrid.Api/PlanGridHttpHandler.cs
@@ -42,7 +42,7 @@ namespace PlanGrid.Api
                     request.Content = new StringContent("", Encoding.UTF8, "application/json");
                 }
 
-                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", authenticationToken);
+                request.Headers.Authorization = "Bearer " + authenticationToken;
                 request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"application/vnd.plangrid+json; version={version}"));
 
                 HttpResponseMessage response = await base.SendAsync(request, cancellationToken);

--- a/PlanGrid.Api/PlanGridHttpHandler.cs
+++ b/PlanGrid.Api/PlanGridHttpHandler.cs
@@ -42,7 +42,7 @@ namespace PlanGrid.Api
                     request.Content = new StringContent("", Encoding.UTF8, "application/json");
                 }
 
-                request.Headers.Authorization = "Bearer " + authenticationToken;
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authenticationToken);
                 request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"application/vnd.plangrid+json; version={version}"));
 
                 HttpResponseMessage response = await base.SendAsync(request, cancellationToken);

--- a/PlanGrid.Api/PlanGridHttpHandler.cs
+++ b/PlanGrid.Api/PlanGridHttpHandler.cs
@@ -42,7 +42,7 @@ namespace PlanGrid.Api
                     request.Content = new StringContent("", Encoding.UTF8, "application/json");
                 }
 
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", authenticationToken);
+                request.Headers.Add("Authorization", "Bearer " + accessToken);
                 request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse($"application/vnd.plangrid+json; version={version}"));
 
                 HttpResponseMessage response = await base.SendAsync(request, cancellationToken);


### PR DESCRIPTION
We should be sending the oauth_* tokens in the header form ```Authorization: Bearer *``` as is described here: https://github.com/plangrid/customer_api_dispatcher#oauth-authentication

We will support the existing authn in centauth but should move to the documented protocol.

Any way to test this? Have no experience with this repo or c#. Need to be sure that ```AuthenticationHeaderValue``` doesn't b64 encode the token value. The server expects ```Bearer oauth_token```

Found this doc which may help: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Using-the-acquired-token-to-call-a-protected-Web-API

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/plangrid/plangrid-api-net/18)
<!-- Reviewable:end -->
